### PR TITLE
Allow trailing commas in array

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1146,6 +1146,9 @@ export function visit(text: string, visitor: JSONVisitor, options?: ParseOptions
 				}
 				onSeparator(',');
 				scanNext(); // consume comma
+				if (_scanner.getToken() === SyntaxKind.CloseBracketToken && allowTrailingComma) {
+					break;
+				}
 			} else if (needsComma) {
 				handleError(ParseErrorCode.CommaExpected, [], []);
 			}

--- a/src/test/json.test.ts
+++ b/src/test/json.test.ts
@@ -244,7 +244,6 @@ suite('JSON', () => {
 
 	test('parse: array with errors', () => {
 		assertInvalidParse('[,]', []);
-		assertInvalidParse('[ 1, 2, ]', [1, 2]);
 		assertInvalidParse('[ 1 2, 3 ]', [1, 2, 3]);
 		assertInvalidParse('[ ,1, 2, 3 ]', [1, 2, 3]);
 		assertInvalidParse('[ ,1, 2, 3, ]', [1, 2, 3]);
@@ -265,9 +264,12 @@ suite('JSON', () => {
 		assertValidParse('{ "hello": [] }', { hello: [] }, options);
 		assertValidParse('{ "hello": [], "world": {}, }', { hello: [], world: {} }, options);
 		assertValidParse('{ "hello": [], "world": {} }', { hello: [], world: {} }, options);
+		assertValidParse('[ 1, 2, ]', [1, 2], options);
+		assertValidParse('[ 1, 2 ]', [1, 2], options);
 
 		assertInvalidParse('{ "hello": [], }', { hello: [] });
 		assertInvalidParse('{ "hello": [], "world": {}, }', { hello: [], world: {} });
+		assertInvalidParse('[ 1, 2, ]', [1, 2]);
 	});
 	test('location: properties', () => {
 		assertLocation('|{ "foo": "bar" }', [], void 0, false);

--- a/src/test/json.test.ts
+++ b/src/test/json.test.ts
@@ -35,9 +35,7 @@ function assertValidParse(input: string, expected: any, options?: ParseOptions):
 	var errors: ParseError[] = [];
 	var actual = parse(input, errors, options);
 
-	if (errors.length !== 0) {
-		assert.notEqual("undefined", typeof errors[0].error);
-	}
+	assert.deepEqual([], errors)
 	assert.deepEqual(actual, expected);
 }
 


### PR DESCRIPTION
Previously, allowTrailingCommas only allowed trailing commas in objects, and it would still return errors for JSON like `[1, 2, ]`. This was surprising to me as a user. Is there a reason for allowing trailing commas in objects but not arrays?

Also fixes the `assertValidParse` helper. It was not failing even when there were parse errors (because it only failed if there were parse errors AND the first parse error's code was `"undefined"`; I couldn't find a case where that would be true).