### PR TITLE
add onLineBreak visit function

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ export interface JSONScanner {
     /**
      * The zero-based start line number of the last read token.
      */
-    getTokenLine(): number;
+    getTokenStartLine(): number;
     /**
-     * The zero-based character (start column) of the last read token.
+     * The zero-based start character (column) of the last read token.
      */
-    getTokenCharacter(): number;
+    getTokenStartCharacter(): number;
     /**
      * An error code of the last scan.
      */

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ export interface JSONScanner {
      * The length of the last read token.
      */
     getTokenLength(): number;
+	/**
+	 * The zero-based start line number of the last read token.
+	 */
+	getTokenLine(): number;
+	/**
+	 * The zero-based character (start column) of the last read token.
+	 */
+	getTokenCharacter(): number;
     /**
      * An error code of the last scan.
      */
@@ -93,42 +101,42 @@ export declare function parse(text: string, errors?: {error: ParseErrorCode;}[],
 export declare function visit(text: string, visitor: JSONVisitor, options?: ParseOptions): any;
 
 export interface JSONVisitor {
-    /**
-     * Invoked when an open brace is encountered and an object is started. The offset and length represent the location of the open brace.
-     */
-    onObjectBegin?: (offset: number, length: number) => void;
-    /**
-     * Invoked when a property is encountered. The offset and length represent the location of the property name.
-     */
-    onObjectProperty?: (property: string, offset: number, length: number) => void;
-    /**
-     * Invoked when a closing brace is encountered and an object is completed. The offset and length represent the location of the closing brace.
-     */
-    onObjectEnd?: (offset: number, length: number) => void;
-    /**
-     * Invoked when an open bracket is encountered. The offset and length represent the location of the open bracket.
-     */
-    onArrayBegin?: (offset: number, length: number) => void;
-    /**
-     * Invoked when a closing bracket is encountered. The offset and length represent the location of the closing bracket.
-     */
-    onArrayEnd?: (offset: number, length: number) => void;
-    /**
-     * Invoked when a literal value is encountered. The offset and length represent the location of the literal value.
-     */
-    onLiteralValue?: (value: any, offset: number, length: number) => void;
-    /**
-     * Invoked when a comma or colon separator is encountered. The offset and length represent the location of the separator.
-     */
-    onSeparator?: (charcter: string, offset: number, length: number) => void;
+	/**
+	 * Invoked when an open brace is encountered and an object is started. The offset and length represent the location of the open brace.
+	 */
+	onObjectBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+	/**
+	 * Invoked when a property is encountered. The offset and length represent the location of the property name.
+	 */
+	onObjectProperty?: (property: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
+	/**
+	 * Invoked when a closing brace is encountered and an object is completed. The offset and length represent the location of the closing brace.
+	 */
+	onObjectEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+	/**
+	 * Invoked when an open bracket is encountered. The offset and length represent the location of the open bracket.
+	 */
+	onArrayBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+	/**
+	 * Invoked when a closing bracket is encountered. The offset and length represent the location of the closing bracket.
+	 */
+	onArrayEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+	/**
+	 * Invoked when a literal value is encountered. The offset and length represent the location of the literal value.
+	 */
+	onLiteralValue?: (value: any, offset: number, length: number, startLine: number, startCharacter: number) => void;
+	/**
+	 * Invoked when a comma or colon separator is encountered. The offset and length represent the location of the separator.
+	 */
+	onSeparator?: (character: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
 	/**
 	 * When comments are allowed, invoked when a line or block comment is encountered. The offset and length represent the location of the comment.
 	 */
-	onComment?: (offset: number, length: number) => void;    
-    /**
-     * Invoked on an error.
-     */
-    onError?: (error: ParseErrorCode, offset: number, length: number) => void;
+	onComment?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+	/**
+	 * Invoked on an error.
+	 */
+	onError?: (error: ParseErrorCode, offset: number, length: number, startLine: number, startCharacter: number) => void;
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ export interface JSONScanner {
      * The length of the last read token.
      */
     getTokenLength(): number;
-	/**
-	 * The zero-based start line number of the last read token.
-	 */
-	getTokenLine(): number;
-	/**
-	 * The zero-based character (start column) of the last read token.
-	 */
-	getTokenCharacter(): number;
+    /**
+     * The zero-based start line number of the last read token.
+     */
+    getTokenLine(): number;
+    /**
+     * The zero-based character (start column) of the last read token.
+     */
+    getTokenCharacter(): number;
     /**
      * An error code of the last scan.
      */
@@ -101,42 +101,42 @@ export declare function parse(text: string, errors?: {error: ParseErrorCode;}[],
 export declare function visit(text: string, visitor: JSONVisitor, options?: ParseOptions): any;
 
 export interface JSONVisitor {
-	/**
-	 * Invoked when an open brace is encountered and an object is started. The offset and length represent the location of the open brace.
-	 */
-	onObjectBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * Invoked when a property is encountered. The offset and length represent the location of the property name.
-	 */
-	onObjectProperty?: (property: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * Invoked when a closing brace is encountered and an object is completed. The offset and length represent the location of the closing brace.
-	 */
-	onObjectEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * Invoked when an open bracket is encountered. The offset and length represent the location of the open bracket.
-	 */
-	onArrayBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * Invoked when a closing bracket is encountered. The offset and length represent the location of the closing bracket.
-	 */
-	onArrayEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * Invoked when a literal value is encountered. The offset and length represent the location of the literal value.
-	 */
-	onLiteralValue?: (value: any, offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * Invoked when a comma or colon separator is encountered. The offset and length represent the location of the separator.
-	 */
-	onSeparator?: (character: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * When comments are allowed, invoked when a line or block comment is encountered. The offset and length represent the location of the comment.
-	 */
-	onComment?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
-	/**
-	 * Invoked on an error.
-	 */
-	onError?: (error: ParseErrorCode, offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked when an open brace is encountered and an object is started. The offset and length represent the location of the open brace.
+     */
+    onObjectBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked when a property is encountered. The offset and length represent the location of the property name.
+     */
+    onObjectProperty?: (property: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked when a closing brace is encountered and an object is completed. The offset and length represent the location of the closing brace.
+     */
+    onObjectEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked when an open bracket is encountered. The offset and length represent the location of the open bracket.
+     */
+    onArrayBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked when a closing bracket is encountered. The offset and length represent the location of the closing bracket.
+     */
+    onArrayEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked when a literal value is encountered. The offset and length represent the location of the literal value.
+     */
+    onLiteralValue?: (value: any, offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked when a comma or colon separator is encountered. The offset and length represent the location of the separator.
+     */
+    onSeparator?: (character: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * When comments are allowed, invoked when a line or block comment is encountered. The offset and length represent the location of the comment.
+     */
+    onComment?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
+    /**
+     * Invoked on an error.
+     */
+    onError?: (error: ParseErrorCode, offset: number, length: number, startLine: number, startCharacter: number) => void;
 }
 
 /**

--- a/src/impl/parser.ts
+++ b/src/impl/parser.ts
@@ -386,10 +386,10 @@ export function visit(text: string, visitor: JSONVisitor, options: ParseOptions 
 	let _scanner = createScanner(text, false);
 
 	function toNoArgVisit(visitFunction?: (offset: number, length: number, startLine: number, startCharacter: number) => void): () => void {
-		return visitFunction ? () => visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenLine(), _scanner.getTokenCharacter()) : () => true;
+		return visitFunction ? () => visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter()) : () => true;
 	}
 	function toOneArgVisit<T>(visitFunction?: (arg: T, offset: number, length: number, startLine: number, startCharacter: number) => void): (arg: T) => void {
-		return visitFunction ? (arg: T) => visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenLine(), _scanner.getTokenCharacter()) : () => true;
+		return visitFunction ? (arg: T) => visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter()) : () => true;
 	}
 
 	let onObjectBegin = toNoArgVisit(visitor.onObjectBegin),

--- a/src/impl/parser.ts
+++ b/src/impl/parser.ts
@@ -6,8 +6,17 @@
 
 import { createScanner } from './scanner';
 import {
-	ScanError, SyntaxKind, Node, NodeType, Edit, JSONPath, FormattingOptions,
-	ModificationOptions, ParseError, ParseErrorCode, Location, Segment, ParseOptions, JSONVisitor
+	JSONPath,
+	JSONVisitor,
+	Location,
+	Node,
+	NodeType,
+	ParseError,
+	ParseErrorCode,
+	ParseOptions,
+	ScanError,
+	Segment,
+	SyntaxKind
 } from '../main';
 
 namespace ParseOptions {
@@ -376,11 +385,11 @@ export function visit(text: string, visitor: JSONVisitor, options: ParseOptions 
 
 	let _scanner = createScanner(text, false);
 
-	function toNoArgVisit(visitFunction?: (offset: number, length: number) => void): () => void {
-		return visitFunction ? () => visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength()) : () => true;
+	function toNoArgVisit(visitFunction?: (offset: number, length: number, startLine: number, startCharacter: number) => void): () => void {
+		return visitFunction ? () => visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenLine(), _scanner.getTokenCharacter()) : () => true;
 	}
-	function toOneArgVisit<T>(visitFunction?: (arg: T, offset: number, length: number) => void): (arg: T) => void {
-		return visitFunction ? (arg: T) => visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength()) : () => true;
+	function toOneArgVisit<T>(visitFunction?: (arg: T, offset: number, length: number, startLine: number, startCharacter: number) => void): (arg: T) => void {
+		return visitFunction ? (arg: T) => visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenLine(), _scanner.getTokenCharacter()) : () => true;
 	}
 
 	let onObjectBegin = toNoArgVisit(visitor.onObjectBegin),

--- a/src/impl/scanner.ts
+++ b/src/impl/scanner.ts
@@ -17,6 +17,10 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 		value: string = '',
 		tokenOffset = 0,
 		token: SyntaxKind = SyntaxKind.Unknown,
+		lineNumber = 0,
+		tokenLineNumber = 0,
+		lineEndOffset = 0,
+		prevLineEndOffset = 0,
 		scanError: ScanError = ScanError.None;
 
 	function scanHexDigits(count: number, exact?: boolean): number {
@@ -179,6 +183,8 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 		scanError = ScanError.None;
 
 		tokenOffset = pos;
+		tokenLineNumber = lineNumber;
+		prevLineEndOffset = lineEndOffset;
 
 		if (pos >= len) {
 			// at the end
@@ -206,6 +212,8 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 				pos++;
 				value += '\n';
 			}
+			lineNumber++;
+			lineEndOffset = pos;
 			return token = SyntaxKind.LineBreakTrivia;
 		}
 
@@ -268,7 +276,17 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 							commentClosed = true;
 							break;
 						}
+
 						pos++;
+
+						if (isLineBreak(ch)) {
+							if (ch === CharacterCodes.carriageReturn && text.charCodeAt(pos) === CharacterCodes.lineFeed) {
+								pos++;
+							}
+
+							lineNumber++;
+							lineEndOffset = pos;
+						}
 					}
 					
 					if (!commentClosed) {
@@ -365,7 +383,9 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 		getTokenValue: () => value,
 		getTokenOffset: () => tokenOffset,
 		getTokenLength: () => pos - tokenOffset,
-		getTokenError: () => scanError
+		getTokenLine: () => tokenLineNumber,
+		getTokenCharacter: () => tokenOffset - prevLineEndOffset,
+		getTokenError: () => scanError,
 	};
 }
 

--- a/src/impl/scanner.ts
+++ b/src/impl/scanner.ts
@@ -18,9 +18,9 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 		tokenOffset = 0,
 		token: SyntaxKind = SyntaxKind.Unknown,
 		lineNumber = 0,
-		tokenLineNumber = 0,
-		lineEndOffset = 0,
-		prevLineEndOffset = 0,
+		lineStartOffset = 0,
+		tokenLineStartOffset = 0,
+		prevTokenLineStartOffset = 0,
 		scanError: ScanError = ScanError.None;
 
 	function scanHexDigits(count: number, exact?: boolean): number {
@@ -183,8 +183,8 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 		scanError = ScanError.None;
 
 		tokenOffset = pos;
-		tokenLineNumber = lineNumber;
-		prevLineEndOffset = lineEndOffset;
+		lineStartOffset = lineNumber;
+		prevTokenLineStartOffset = tokenLineStartOffset;
 
 		if (pos >= len) {
 			// at the end
@@ -213,7 +213,7 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 				value += '\n';
 			}
 			lineNumber++;
-			lineEndOffset = pos;
+			tokenLineStartOffset = pos;
 			return token = SyntaxKind.LineBreakTrivia;
 		}
 
@@ -285,7 +285,7 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 							}
 
 							lineNumber++;
-							lineEndOffset = pos;
+							tokenLineStartOffset = pos;
 						}
 					}
 					
@@ -383,8 +383,8 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 		getTokenValue: () => value,
 		getTokenOffset: () => tokenOffset,
 		getTokenLength: () => pos - tokenOffset,
-		getTokenLine: () => tokenLineNumber,
-		getTokenCharacter: () => tokenOffset - prevLineEndOffset,
+		getTokenStartLine: () => lineStartOffset,
+		getTokenStartCharacter: () => tokenOffset - prevTokenLineStartOffset,
 		getTokenError: () => scanError,
 	};
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,14 @@ export interface JSONScanner {
 	 */
 	getTokenLength(): number;
 	/**
+	 * The zero-based start line number of the last read token.
+	 */
+	getTokenLine(): number;
+	/**
+	 * The zero-based character (start column) of the last read token.
+	 */
+	getTokenCharacter(): number;
+	/**
 	 * An error code of the last scan.
 	 */
 	getTokenError(): ScanError;
@@ -225,47 +233,47 @@ export interface JSONVisitor {
 	/**
 	 * Invoked when an open brace is encountered and an object is started. The offset and length represent the location of the open brace.
 	 */
-	onObjectBegin?: (offset: number, length: number) => void;
+	onObjectBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * Invoked when a property is encountered. The offset and length represent the location of the property name.
 	 */
-	onObjectProperty?: (property: string, offset: number, length: number) => void;
+	onObjectProperty?: (property: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * Invoked when a closing brace is encountered and an object is completed. The offset and length represent the location of the closing brace.
 	 */
-	onObjectEnd?: (offset: number, length: number) => void;
+	onObjectEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * Invoked when an open bracket is encountered. The offset and length represent the location of the open bracket.
 	 */
-	onArrayBegin?: (offset: number, length: number) => void;
+	onArrayBegin?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * Invoked when a closing bracket is encountered. The offset and length represent the location of the closing bracket.
 	 */
-	onArrayEnd?: (offset: number, length: number) => void;
+	onArrayEnd?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * Invoked when a literal value is encountered. The offset and length represent the location of the literal value.
 	 */
-	onLiteralValue?: (value: any, offset: number, length: number) => void;
+	onLiteralValue?: (value: any, offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * Invoked when a comma or colon separator is encountered. The offset and length represent the location of the separator.
 	 */
-	onSeparator?: (character: string, offset: number, length: number) => void;
+	onSeparator?: (character: string, offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * When comments are allowed, invoked when a line or block comment is encountered. The offset and length represent the location of the comment.
 	 */
-	onComment?: (offset: number, length: number) => void;
+	onComment?: (offset: number, length: number, startLine: number, startCharacter: number) => void;
 
 	/**
 	 * Invoked on an error.
 	 */
-	onError?: (error: ParseErrorCode, offset: number, length: number) => void;
+	onError?: (error: ParseErrorCode, offset: number, length: number, startLine: number, startCharacter: number) => void;
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,11 +80,11 @@ export interface JSONScanner {
 	/**
 	 * The zero-based start line number of the last read token.
 	 */
-	getTokenLine(): number;
+	getTokenStartLine(): number;
 	/**
-	 * The zero-based character (start column) of the last read token.
+	 * The zero-based start character (column) of the last read token.
 	 */
-	getTokenCharacter(): number;
+	getTokenStartCharacter(): number;
 	/**
 	 * An error code of the last scan.
 	 */


### PR DESCRIPTION
The PR implements an extra and optional `onLineBreak` function.
At the moment, jsonc-parser make use of offset and length for positional info, which is totally fine.
Unfortunately, quite a few tools/editors operate on lines and columns, therefore integrating jsonc-parser is a bit more troublesome, since you need to fall back to scanner/tokenizer and perform the entire parsing process (At least, I couldn't find any reasonable way to implement positional info based on columns and lines without the use of scanner).
Hope the above reasoning makes sense.
I am not sure about the presence of `lineNumber` and whether it should be zero-based or not. I believe we could get rid of it and let the consumer implement it if needed.
Moreover, I'm afraid we cannot really handle line breaks in multi-line comments due to the way these comments are parsed.
