### PR TITLE
Optimize parseLiteral for number-heavy JSON files (ala GeoJSON)

### DIFF
--- a/src/impl/parser.ts
+++ b/src/impl/parser.ts
@@ -482,16 +482,21 @@ export function visit(text: string, visitor: JSONVisitor, options: ParseOptions 
 	function parseLiteral(): boolean {
 		switch (_scanner.getToken()) {
 			case SyntaxKind.NumericLiteral:
-				let value = 0;
-				try {
-					value = JSON.parse(_scanner.getTokenValue());
-					if (typeof value !== 'number') {
+				const tokenValue = _scanner.getTokenValue();
+				let value = parseFloat(tokenValue);
+
+				if (isNaN(value)) {
+					try {
+						value = JSON.parse(tokenValue);
+						if (typeof value !== 'number') {
+							handleError(ParseErrorCode.InvalidNumberFormat);
+							value = 0;
+						}
+					} catch (e) {
 						handleError(ParseErrorCode.InvalidNumberFormat);
-						value = 0;
 					}
-				} catch (e) {
-					handleError(ParseErrorCode.InvalidNumberFormat);
 				}
+
 				onLiteralValue(value);
 				break;
 			case SyntaxKind.NullKeyword:

--- a/src/impl/parser.ts
+++ b/src/impl/parser.ts
@@ -483,18 +483,11 @@ export function visit(text: string, visitor: JSONVisitor, options: ParseOptions 
 		switch (_scanner.getToken()) {
 			case SyntaxKind.NumericLiteral:
 				const tokenValue = _scanner.getTokenValue();
-				let value = parseFloat(tokenValue);
+				let value = Number(tokenValue);
 
 				if (isNaN(value)) {
-					try {
-						value = JSON.parse(tokenValue);
-						if (typeof value !== 'number') {
-							handleError(ParseErrorCode.InvalidNumberFormat);
-							value = 0;
-						}
-					} catch (e) {
-						handleError(ParseErrorCode.InvalidNumberFormat);
-					}
+					handleError(ParseErrorCode.InvalidNumberFormat);
+					value = 0;
 				}
 
 				onLiteralValue(value);


### PR DESCRIPTION
When parsing number-heavy files like GeoJSON, trying the naive `parseFloat` first then going for full JSON compatibility if `NaN` provides meaningful performance benefits.

Tried on a 75MB GeoJSON file, raw parse time was ~3500ms before change and ~2600-2700ms after.

Best.