### PR TITLE
findNodeAtLocation does not handle incomplete property pair

### DIFF
--- a/src/impl/parser.ts
+++ b/src/impl/parser.ts
@@ -288,7 +288,7 @@ export function findNodeAtLocation(root: Node | undefined, path: JSONPath): Node
 			}
 			let found = false;
 			for (const propertyNode of node.children) {
-				if (Array.isArray(propertyNode.children) && propertyNode.children[0].value === segment) {
+				if (Array.isArray(propertyNode.children) && propertyNode.children[0].value === segment && propertyNode.children.length === 2) {
 					node = propertyNode.children[1];
 					found = true;
 					break;

--- a/src/test/json.test.ts
+++ b/src/test/json.test.ts
@@ -575,7 +575,7 @@ suite('JSON', () => {
 	});
 
 	test('tree: find location', () => {
-		let root = parseTree('{ "key1": { "key11": [ "val111", "val112" ] }, "key2": [ { "key21": false, "key22": 221 }, null, [{}] ] }');
+		let root = parseTree('{ "key1": { "key11": [ "val111", "val112" ] }, "key2": [ { "key21": false, "key22": 221 }, null, [{}] ], "key3": { "key31":, "key32": 32 } }');
 		assertNodeAtLocation(root, ['key1'], { key11: ['val111', 'val112'] });
 		assertNodeAtLocation(root, ['key1', 'key11'], ['val111', 'val112']);
 		assertNodeAtLocation(root, ['key1', 'key11', 0], 'val111');
@@ -586,6 +586,8 @@ suite('JSON', () => {
 		assertNodeAtLocation(root, ['key2', 1], null);
 		assertNodeAtLocation(root, ['key2', 2], [{}]);
 		assertNodeAtLocation(root, ['key2', 2, 0], {});
+		assertNodeAtLocation(root, ['key3', 'key31', 'key311'], undefined);
+		assertNodeAtLocation(root, ['key3', 'key32'], 32);
 	});
 
 	test('location: matches', () => {


### PR DESCRIPTION
Rather not a big of a deal considering the document is not syntactically valid, but I believe it might be good to handle it gracefully rather than throwing a TypeError.