### PR TITLE
Make final two arguments of modify() and format() optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ export function getNodeValue(node: Node): any;
  * the same offset, for example multiple inserts, or an insert followed by a remove or replace. The order in the array defines which edit is applied first.
  * To apply edits to an input, you can use `applyEdits`
  */
-export function format(documentText: string, range: Range, options: FormattingOptions): Edit[];
+export function format(documentText: string, range?: Range, options?: FormattingOptions): Edit[];
 
 
 /**
@@ -244,7 +244,7 @@ export function format(documentText: string, range: Range, options: FormattingOp
  * the same offset, for example multiple inserts, or an insert followed by a remove or replace. The order in the array defines which edit is applied first.
  * To apply edits to an input, you can use `applyEdits`
  */
-export function modify(text: string, path: JSONPath, value: any, options: ModificationOptions): Edit[];
+export function modify(text: string, path: JSONPath, value?: any, options?: ModificationOptions): Edit[];
 
 /**
  * Applies edits to a input string.

--- a/src/main.ts
+++ b/src/main.ts
@@ -339,8 +339,8 @@ export interface FormattingOptions {
  * the same offset, for example multiple inserts, or an insert followed by a remove or replace. The order in the array defines which edit is applied first.
  * To apply edits to an input, you can use `applyEdits`.
  */
-export function format(documentText: string, range: Range | undefined, options: FormattingOptions): Edit[] {
-	return formatter.format(documentText, range, options);
+export function format(documentText: string, range?: Range | undefined, options?: FormattingOptions): Edit[] {
+	return formatter.format(documentText, range, options || {});
 }
 
 /** 
@@ -377,8 +377,8 @@ export interface ModificationOptions {
  * the same offset, for example multiple inserts, or an insert followed by a remove or replace. The order in the array defines which edit is applied first.
  * To apply edits to an input, you can use `applyEdits`.
  */
-export function modify(text: string, path: JSONPath, value: any, options: ModificationOptions): Edit[] {
-	return edit.setProperty(text, path, value, options);
+export function modify(text: string, path: JSONPath, value?: any, options?: ModificationOptions): Edit[] {
+	return edit.setProperty(text, path, value, options || {});
 }
 
 /**


### PR DESCRIPTION
Both modify() and format(), the final two arguments could potentially be omitted because there are "obvious" defaults. In both cases, the next-to-last argument actually accepts "undefined", but they're not optional arguments so you have to type out "undefined".

This patch adds question marks? as appropriate in the typing, and explicitly turns an "undefined" argument for FormattingOptions/ModificationOptions into an empty table. I think this would be more convenient. I tested these changes with `npm run test` but did not write any new tests.