### PR TITLE
An additional parameter keepLines has been added into the formatting options which allows to keep the original line formatting (#66)

### DIFF
--- a/src/test/format.test.ts
+++ b/src/test/format.test.ts
@@ -571,6 +571,7 @@ suite('JSON - formatter', () => {
 		format(content, expected, true, false, true);
 	});
 
+	// some change
 	test('multiple line breaks are kept', () => {
 		const content = [
 			'{"settings":',


### PR DESCRIPTION
* An additional parameter keepLines has been added into the formatting options which allows to keep the original line formatting

* Resolving the reviews and simplifying the code with the function `multipleLineBreaks`

* Reverting back to the previous commit and applying the review changes

* cleaning the code, simplifying the if/else cases

* Updating the dependencies of package.json to their latest versions. Changed `withFormatting` so that keepLines option is always false.

* Solving "Invalid: lock file's ... does not satisfy"

* testing if higher node version in .travis.yml will solve the failing of CI

* formatting and let-> const, avoid modification of options

Co-authored-by: Martin Aeschlimann <martinae@microsoft.com>