### PR TITLE
perf(format): cache breaklines and spaces as much as possible

### DIFF
--- a/src/impl/string-intern.ts
+++ b/src/impl/string-intern.ts
@@ -1,0 +1,33 @@
+export const cachedSpaces = new Array(20).fill(0).map((_, index) => {
+  return ' '.repeat(index);
+});
+
+const maxCachedValues = 200;
+
+export const cachedBreakLinesWithSpaces = {
+  ' ': {
+    '\n': new Array(maxCachedValues).fill(0).map((_, index) => {
+      return '\n' + ' '.repeat(index);
+    }),
+    '\r': new Array(maxCachedValues).fill(0).map((_, index) => {
+      return '\r' + ' '.repeat(index);
+    }),
+    '\r\n': new Array(maxCachedValues).fill(0).map((_, index) => {
+      return '\r\n' + ' '.repeat(index);
+    }),
+  },
+	'\t': {
+    '\n': new Array(maxCachedValues).fill(0).map((_, index) => {
+      return '\n' + '\t'.repeat(index);
+    }),
+    '\r': new Array(maxCachedValues).fill(0).map((_, index) => {
+      return '\r' + '\t'.repeat(index);
+    }),
+    '\r\n': new Array(maxCachedValues).fill(0).map((_, index) => {
+      return '\r\n' + '\t'.repeat(index);
+    }),
+	}
+};
+
+export const supportedEols = ['\n', '\r', '\r\n'] as const;
+export type SupportedEOL = '\n' | '\r' | '\r\n';

--- a/src/test/string-intern.test.ts
+++ b/src/test/string-intern.test.ts
@@ -1,0 +1,20 @@
+import { cachedBreakLinesWithSpaces, cachedSpaces, supportedEols } from '../impl/string-intern';
+import * as assert from 'assert';
+
+suite('string intern', () => {
+  test('should correctly define spaces intern', () => {
+    for (let i = 0; i < cachedSpaces.length; i++) {
+      assert.strictEqual(cachedSpaces[i], ' '.repeat(i));
+    }
+  });
+
+  test('should correctly define break lines with spaces intern', () => {
+    for (const indentType of [' ', '\t'] as const) {
+      for (const eol of supportedEols) {
+        for (let i = 0; i < cachedBreakLinesWithSpaces[indentType][eol].length; i++) {
+          assert.strictEqual(cachedBreakLinesWithSpaces[indentType][eol][i], eol + indentType.repeat(i));
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR basically tries to cache as much as possible the strings and spaces created since they are basically the same, there's no need to allocate new memory for those strings.

This optimization affects `eol`:

- `\r`
- `\n`
- `\r\n`

This optimization will only cache strings up to `200` characters (it was chosen just because it speedups `tabSize=4` for this huge json).

In the happy path, this algorithm will only allocate memory for the array and the objects, but not for the `content`.

For smaller files, this change didn't make the code run faster, this is only valid for larger json.

Before:

```
End: 2431.62ms
RSS: 2290.38671875MB
Amount of edits: 7876047
```

After:

```
End: 989.64ms
RSS: 709.5234375MB
Amount of edits: 7876047
```

Benchmark:

```js
const heavyJson = require('fs').readFileSync('./rrdom-benchmark-1.json', 'utf8');

const lib = require('./lib/umd/main');

const startTime = performance.now();
const edits = lib.format(heavyJson, undefined, {
  tabSize: 2,
  insertFinalNewline: true,
  insertSpaces: true,
});
console.log(`End: ${(performance.now() - startTime).toFixed(2)}ms`);
console.log(`RSS: ${process.memoryUsage.rss() / 1024 / 1024}MB`);
console.log(`Amount of edits: ${edits.length}`);
```

Large Json: [rrdom-benchmark-1.json.zip](https://github.com/microsoft/node-jsonc-parser/files/13925355/rrdom-benchmark-1.json.zip)
