### PR TITLE
feat: format with generator

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -306,6 +306,11 @@ export interface JSONVisitor {
 export type EditResult = Edit[];
 
 /**
+ * See more {@link EditResult}
+ */
+export type EditGeneratorResult = Generator<Edit, void, void>;
+
+/**
  * Represents a text modification
  */
 export interface Edit {
@@ -374,6 +379,19 @@ export interface FormattingOptions {
  */
 export function format(documentText: string, range: Range | undefined, options: FormattingOptions): EditResult {
 	return formatter.format(documentText, range, options);
+}
+
+/**
+ * Computes the edit operations needed to format a JSON document.
+ * 
+ * @param documentText The input text 
+ * @param range The range to format or `undefined` to format the full content
+ * @param options The formatting options
+ * @returns The edit operations describing the formatting changes to the original document following the format described in {@linkcode EditResult}.
+ * To apply the edit operations to the input, use {@linkcode applyEdits}.
+ */
+export function formatGenerator(documentText: string, range: Range | undefined, options: FormattingOptions): EditGeneratorResult {
+	return formatter.formatGenerator(documentText, range, options);
 }
 
 /** 


### PR DESCRIPTION
This PR adds a new method to be able to consume the `format` edits using generators, which can help reduce the amount of memory needed to process a heavier json.

With the current implementation, using the benchmark of #81, we had a slowdown while using `sync` result:

```
End: 1264.72ms
RSS: 693.6484375MB
```

But, if we consider how this API can be used, for example to replace the current implementation of [format on vscode-json-language-service](https://github.com/microsoft/vscode-json-languageservice/blob/5692bed6db771d0f8985f89a9ecd9e3bc96cbc00/src/utils/format.ts#L18-L20), we have good results:

Before:

```
End of Sync: 1832.79ms
RSS: 937.5625MB
```

<details>
<summary>text-format-with-map.js</summary>

```js
const heavyJson = require('fs').readFileSync('./rrdom-benchmark-1.json', 'utf8');

const lib = require('./lib/umd/main');

class Range {
  construtor(start, end) {
    this.start = start;
    this.end = end;
  }
}

class TextEdit {
  construtor(range, content) {
    this.range = range;
    this.content = content;
  }
}

const startTime = performance.now();
const edits = lib.format(heavyJson, undefined, {
  tabSize: 2,
  insertFinalNewline: true,
  insertSpaces: true,
});
const mappedEdits = edits.map(e => {
  return new TextEdit(
    new Range(e.offset, e.offset + e.length),
    e.content,
  );
});
console.log(`End of Sync: ${(performance.now() - startTime).toFixed(2)}ms`);
console.log(`RSS: ${process.memoryUsage.rss() / 1024 / 1024}MB`);
```
</details>

After:

```
End of Generator: 1661.84ms
RSS: 471.7890625MB
```

<details>
<summary>test-format-with-map-generator.js</summary>

```js
const heavyJson = require('fs').readFileSync('./rrdom-benchmark-1.json', 'utf8');

const lib = require('./lib/umd/main');

class Range {
  construtor(start, end) {
    this.start = start;
    this.end = end;
  }
}

class TextEdit {
  construtor(range, content) {
    this.range = range;
    this.content = content;
  }
}

const startTime = performance.now();
const mappedEdits = [];

for (const e of lib.formatGenerator(heavyJson, undefined, {
  tabSize: 2,
  insertFinalNewline: true,
  insertSpaces: true,
})) {
  mappedEdits.push(new TextEdit(
    new Range(e.offset, e.offset + e.length),
    e.content,
  ));
}

console.log(`End of Generator: ${(performance.now() - startTime).toFixed(2)}ms`);
console.log(`RSS: ${process.memoryUsage.rss() / 1024 / 1024}MB`);
```

</details>

This new approach will be faster and also will consume less memory :rocket: