### PR TITLE
perf(format): add fast path using json stringify/parse

### DIFF
--- a/src/impl/format.ts
+++ b/src/impl/format.ts
@@ -36,6 +36,24 @@ export function format(documentText: string, range: Range | undefined, options: 
 	}
 	const eol = getEOL(options, documentText);
 
+	if (eol === '\n' && options.insertSpaces && !options.keepLines && rangeStart === 0 && rangeEnd === documentText.length) {
+		try {
+			let formatted = JSON.stringify(JSON.parse(documentText), null, options?.tabSize || 4);
+
+			if (options.insertFinalNewline) {
+				formatted += '\n';
+			}
+
+			return [{ 
+				offset: 0,
+				length: documentText.length, 
+				content: formatted
+			}];
+		} catch (e) {
+			// ignore because there is an error on JSON and we will try format until we reach that error.
+		}
+	}
+
 	let numberLineBreaks = 0;
 
 	let indentLevel = 0;


### PR DESCRIPTION
A weird way to optimize but it works:

Conditions:

- `eol` should be `\n`.
- `range` is not supported.
- `keepLines` is not supported.

Before:

> node test-format-heavy-file.js
```
End: 2445.59ms
RSS: 2290.83984375MB
Amount of edits: 7876047
```

> node test-format-heavy-file-formatted.js
```
End: 2560.07ms
RSS: 420.390625MB
Amount of edits: 1
```

After:

> node test-format-heavy-file.js
```
End: 928.96ms
RSS: 610.75MB
Amount of edits: 1
```

> node test-format-heavy-file-formatted.js
```
End: 912.79ms
RSS: 890.671875MB
Amount of edits: 1
```

Benchmarks:

<details>
<summary>test-format-heavy-file.js</summary>

```js
const heavyJson = require('fs').readFileSync('./rrdom-benchmark-1.json', 'utf8');

const lib = require('./lib/umd/main');

const startTime = performance.now();
const edits = lib.format(heavyJson, undefined, {
  tabSize: 2,
  insertFinalNewline: true,
  insertSpaces: true,
});
console.log(`End: ${(performance.now() - startTime).toFixed(2)}ms`);
console.log(`RSS: ${process.memoryUsage.rss() / 1024 / 1024}MB`);
console.log(`Amount of edits: ${edits.length}`);
```
</details>

<details>
<summary>test-format-heavy-file-formatted.js</summary>

```js
const heavyJson = require('fs').readFileSync('./rrdom-benchmark-1-formatted.json', 'utf8');

const lib = require('./lib/umd/main');

const startTime = performance.now();
const edits = lib.format(heavyJson, undefined, {
  tabSize: 2,
  insertFinalNewline: true,
  insertSpaces: true,
});
console.log(`End: ${(performance.now() - startTime).toFixed(2)}ms`);
console.log(`RSS: ${process.memoryUsage.rss() / 1024 / 1024}MB`);
console.log(`Amount of edits: ${edits.length}`);
```
</details>

Assets:
- [rrdom-benchmark-1.json.zip](https://github.com/microsoft/node-jsonc-parser/files/13929196/rrdom-benchmark-1.json.zip)
- [rrdom-benchmark-1-formatted.json.zip](https://github.com/microsoft/node-jsonc-parser/files/13929201/rrdom-benchmark-1-formatted.json.zip)
