### PR TITLE
Allow the visitor to cease callbacks

### DIFF
--- a/src/impl/parser.ts
+++ b/src/impl/parser.ts
@@ -389,25 +389,48 @@ export function visit(text: string, visitor: JSONVisitor, options: ParseOptions 
 	// Important: Only pass copies of this to visitor functions to prevent accidental modification, and
 	// to not affect visitor functions which stored a reference to a previous JSONPath
 	const _jsonPath: JSONPath = [];
+	
+	// Depth of onXXXBegin() callbacks suppressed. onXXXEnd() decrements this if it isn't 0 already.
+	// Callbacks are only called when this value is 0.
+	let suppressedCallbacks = 0;
 
 	function toNoArgVisit(visitFunction?: (offset: number, length: number, startLine: number, startCharacter: number) => void): () => void {
-		return visitFunction ? () => visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter()) : () => true;
+		return visitFunction ? () => suppressedCallbacks === 0 && visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter()) : () => true;
 	}
 	function toNoArgVisitWithPath(visitFunction?: (offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => void): () => void {
-		return visitFunction ? () => visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter(), () => _jsonPath.slice()) : () => true;
+		return visitFunction ? () => suppressedCallbacks === 0 && visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter(), () => _jsonPath.slice()) : () => true;
 	}
 	function toOneArgVisit<T>(visitFunction?: (arg: T, offset: number, length: number, startLine: number, startCharacter: number) => void): (arg: T) => void {
-		return visitFunction ? (arg: T) => visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter()) : () => true;
+		return visitFunction ? (arg: T) => suppressedCallbacks === 0 && visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter()) : () => true;
 	}
 	function toOneArgVisitWithPath<T>(visitFunction?: (arg: T, offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => void): (arg: T) => void {
-		return visitFunction ? (arg: T) => visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter(), () => _jsonPath.slice()) : () => true;
+		return visitFunction ? (arg: T) => suppressedCallbacks === 0 && visitFunction(arg, _scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter(), () => _jsonPath.slice()) : () => true;
+	}
+	function toBeginVisit(visitFunction?: (offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => boolean | void): () => void {
+		return visitFunction ?
+			() => {
+				if (suppressedCallbacks > 0) { suppressedCallbacks++; }
+				else {
+					let cbReturn = visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter(), () => _jsonPath.slice());
+					if (typeof cbReturn === 'boolean' && !cbReturn) { suppressedCallbacks = 1; }
+				}
+			}
+		: () => true;
+	}
+	function toEndVisit(visitFunction?: (offset: number, length: number, startLine: number, startCharacter: number) => void): () => void {
+		return visitFunction ?
+			() => {
+				if (suppressedCallbacks > 0) { suppressedCallbacks--; }
+				if (suppressedCallbacks === 0) { visitFunction(_scanner.getTokenOffset(), _scanner.getTokenLength(), _scanner.getTokenStartLine(), _scanner.getTokenStartCharacter()); }
+			}
+		: () => true;
 	}
 
-	const onObjectBegin = toNoArgVisitWithPath(visitor.onObjectBegin),
+	const onObjectBegin = toBeginVisit(visitor.onObjectBegin),
 		onObjectProperty = toOneArgVisitWithPath(visitor.onObjectProperty),
-		onObjectEnd = toNoArgVisit(visitor.onObjectEnd),
-		onArrayBegin = toNoArgVisitWithPath(visitor.onArrayBegin),
-		onArrayEnd = toNoArgVisit(visitor.onArrayEnd),
+		onObjectEnd = toEndVisit(visitor.onObjectEnd),
+		onArrayBegin = toBeginVisit(visitor.onArrayBegin),
+		onArrayEnd = toEndVisit(visitor.onArrayEnd),
 		onLiteralValue = toOneArgVisitWithPath(visitor.onLiteralValue),
 		onSeparator = toOneArgVisit(visitor.onSeparator),
 		onComment = toNoArgVisit(visitor.onComment),

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,7 +248,7 @@ export interface JSONVisitor {
 	/**
 	 * Invoked when an open brace is encountered and an object is started. The offset and length represent the location of the open brace.
 	 */
-	onObjectBegin?: (offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => void;
+	onObjectBegin?: (offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => boolean | void;
 
 	/**
 	 * Invoked when a property is encountered. The offset and length represent the location of the property name.
@@ -265,7 +265,7 @@ export interface JSONVisitor {
 	/**
 	 * Invoked when an open bracket is encountered. The offset and length represent the location of the open bracket.
 	 */
-	onArrayBegin?: (offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => void;
+	onArrayBegin?: (offset: number, length: number, startLine: number, startCharacter: number, pathSupplier: () => JSONPath) => boolean | void;
 
 	/**
 	 * Invoked when a closing bracket is encountered. The offset and length represent the location of the closing bracket.


### PR DESCRIPTION
As per #30, this PR implements a new feature whereby the callbacks for `onObjectBegin` and `onArrayBegin` for the `JSONVisitor` may return a `boolean` (rather than an arbitrary ignored value as was previously the case) which indicates whether the visitor should continue receiving callbacks for the subtree.

As an example, consider the following JSON:

```json
{
    "a": {
        "b": [ {
            "c": "d",
            "e": "f",
        } ]
    }
}
```

If, upon receiving the `onArrayBegin` callback from the array of `b`, the user returns `false` from the callback, then **all other callbacks** for everything within the array will be suppressed, and the next callback the user receives will **only** be the corresponding `onArrayEnd`.

Internally, this works by keeping a counter `suppressedCallbacks` within `visit()`, which keeps track of the "depth" of the subtree where callbacks are being suppressed. When a new `onXXXBegin()` callback is called and this depth is nonzero, it is incremented. Similarly, when an `onXXXEnd()` callback is called, the depth is decremented, and callbacks are only called when the counter is `0`. This also meant creating new callback adapters (?) such as `toBeginVisit` and `toEndVisit` that handle this counter logic on top of wrapping the actual callback. These were modeled after the original `toNoArgVisitWithPath`/`toNoArgVisit` functions.

FWIW, I've changed the return type of the two begin callbacks to `boolean | void` rather than just `boolean`, so as to preserve some backward compatibility for users who weren't just returning garbage from the callbacks. However, this also meant some refactoring to other parts of the codebase that didn't quite comply with a strict `void` return.

I've also added additional parameters to the `assertVisit` function to test stopping callbacks at a certain position within the JSON (as long as an `onArrayBegin` or `onObjectBegin` callback can be triggered at the specified position). In order to adapt the fact that the begin callbacks now return `boolean`s, I added a `beginHalder` which handles the logic of returning `false` when appropriate.

I'd appreciate it if you would be kind enough to review my code. Let me know what you think!
Thank you!