### PR TITLE
Fix ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,5 +27,10 @@
         "no-unused-expressions": "warn",
         "no-duplicate-imports": "warn",
         "new-parens": "warn"
-    }
+    },
+    "overrides": [
+        {
+            "files": ["*.ts"]
+        }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "clean": "rimraf lib",
     "watch": "tsc -w -p ./src",
     "test": "npm run compile && mocha ./lib/umd/test",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint ."
   }
 }


### PR DESCRIPTION
You shouldn’t pass globs to ESLint. Instead, it should receive `.` (or no positional arguments starting with ESLint 9), and additional extensions should be configured with overrides in the configuration files. Now all JavaScript and TypeScript files in the repository are linted.