### PR TITLE
Add startLine & startCharacter to parser errors

### DIFF
--- a/src/impl/parser.ts
+++ b/src/impl/parser.ts
@@ -197,8 +197,8 @@ export function parse(text: string, errors: ParseError[] = [], options: ParseOpt
 			currentParent = previousParents.pop();
 		},
 		onLiteralValue: onValue,
-		onError: (error: ParseErrorCode, offset: number, length: number) => {
-			errors.push({ error, offset, length });
+		onError: (error: ParseErrorCode, offset: number, length: number, startLine: number, startCharacter: number) => {
+			errors.push({ error, offset, length, startLine, startCharacter });
 		}
 	};
 	visit(text, visitor, options);
@@ -260,8 +260,8 @@ export function parseTree(text: string, errors: ParseError[] = [], options: Pars
 				}
 			}
 		},
-		onError: (error: ParseErrorCode, offset: number, length: number) => {
-			errors.push({ error, offset, length });
+		onError: (error: ParseErrorCode, offset: number, length: number, startLine: number, startCharacter: number) => {
+			errors.push({ error, offset, length, startLine, startCharacter });
 		}
 	};
 	visit(text, visitor, options);

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,6 +144,8 @@ export interface ParseError {
 	error: ParseErrorCode;
 	offset: number;
 	length: number;
+	startLine: number;
+	startCharacter: number;
 }
 
 export const enum ParseErrorCode {

--- a/src/test/json.test.ts
+++ b/src/test/json.test.ts
@@ -431,8 +431,8 @@ suite('JSON', () => {
 					}
 				]
 			}, [
-			{ error: ParseErrorCode.PropertyNameExpected, offset: 26, length: 1 },
-			{ error: ParseErrorCode.ValueExpected, offset: 26, length: 1 }
+			{ error: ParseErrorCode.PropertyNameExpected, offset: 26, length: 1, startLine: 0, startCharacter: 26 },
+			{ error: ParseErrorCode.ValueExpected, offset: 26, length: 1, startLine: 0, startCharacter: 26 }
 		]);
 	});
 
@@ -678,7 +678,7 @@ suite('JSON', () => {
 					], colonOffset: 37
 				}
 			]
-		}, [{ error: ParseErrorCode.ColonExpected, offset: 49, length: 1 }]);
+		}, [{ error: ParseErrorCode.ColonExpected, offset: 49, length: 1, startLine: 0, startCharacter: 49 }]);
 	});
 
 	test('tree: find location', () => {


### PR DESCRIPTION
If you're parsing JSON and providing feedback about errors to a user or developer, a specific line & character is more useful than an offset.

JSONVisitor `onError` already exposes this information, but `parse()` and `parseTree()` did not. This tiny change just exposes the existing error details on all ParseErrors.

This fixes #1 (already closed, but there's ongoing debate there about adding line & character information).